### PR TITLE
Fix build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["Paho Lurie-Gregg <paho@paholg.com>"]
 
 [dependencies]
-  typenum = "*"
-  generic-array = "*"
+  typenum = "1.11.2"
+  generic-array = "0.13.2"
 

--- a/examples/subtract.rs
+++ b/examples/subtract.rs
@@ -2,8 +2,8 @@
 extern crate typenum;
 extern crate minsky;
 
+use minsky::{Decrement, Execute, Halt, Increment, ToGA};
 use typenum::consts::*;
-use minsky::{Execute, Decrement, Increment, Halt, ToGA};
 
 type Instructions = tarr![
     Decrement<U1, U3, U1>,
@@ -25,8 +25,10 @@ fn main() {
     use minsky::Idx;
     use typenum::Unsigned;
     type Difference = Idx<Result, U0>;
-    println!("Computation performed: {} - {} = {:?}",
-             Minuend::to_usize(),
-             Subtrahend::to_usize(),
-             <Difference as Unsigned>::to_usize());
+    println!(
+        "Computation performed: {} - {} = {:?}",
+        Minuend::to_usize(),
+        Subtrahend::to_usize(),
+        <Difference as Unsigned>::to_usize()
+    );
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,9 +1,8 @@
 //! Stolen from dimensioned and modified for unsigned integers
 
-use typenum::{Add1, B1, Length, TArr, ATerm, Len, Unsigned, U0};
-use generic_array::{GenericArray, ArrayLength};
+use generic_array::{ArrayLength, GenericArray};
 use std::ops::Add;
-
+use typenum::{ATerm, Add1, Len, Length, TArr, Unsigned, B1, U0};
 
 pub trait ToGA {
     /// The type of the `GenericArray` to which we've converted
@@ -12,21 +11,20 @@ pub trait ToGA {
     fn to_ga() -> Self::Output;
 }
 
-
 impl ToGA for ATerm {
     type Output = GenericArray<usize, U0>;
     fn to_ga() -> Self::Output {
-        GenericArray::new()
+        GenericArray::default()
     }
 }
 
-
 impl<V, A> ToGA for TArr<V, A>
-    where V: Unsigned,
-          A: Len + ToGA,
-          <A as ToGA>::Output: AppendFront<usize>,
-          Length<A>: Add<B1>,
-          Add1<Length<A>>: Unsigned + ArrayLength<usize>
+where
+    V: Unsigned,
+    A: Len + ToGA,
+    <A as ToGA>::Output: AppendFront<usize>,
+    Length<A>: Add<B1>,
+    Add1<Length<A>>: Unsigned + ArrayLength<usize>,
 {
     type Output = <<A as ToGA>::Output as AppendFront<usize>>::Output;
     fn to_ga() -> Self::Output {
@@ -42,13 +40,14 @@ pub trait AppendFront<T> {
 }
 
 impl<T, N> AppendFront<T> for GenericArray<T, N>
-    where T: Default,
-          N: Add<B1> + ArrayLength<T>,
-          Add1<N>: ArrayLength<T>
+where
+    T: Default,
+    N: Add<B1> + ArrayLength<T>,
+    Add1<N>: ArrayLength<T>,
 {
     type Output = GenericArray<T, Add1<N>>;
     fn append_front(self, element: T) -> Self::Output {
-        let mut a = GenericArray::new();
+        let mut a = GenericArray::default();
         a[0] = element;
         for (i, el) in self.into_iter().enumerate() {
             a[i + 1] = el;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-extern crate typenum;
 extern crate generic_array;
+extern crate typenum;
 
+use std::marker::PhantomData;
 use std::ops::*;
 use typenum::*;
-use std::marker::PhantomData;
 
 mod array;
 pub use array::ToGA;
@@ -22,7 +22,11 @@ impl<V, A> Index<U0> for TArr<V, A> {
     type Output = V;
 }
 
-impl<U, B, V, A> Index<UInt<U, B>> for TArr<V, A> where UInt<U, B>: Sub<B1>, A: Index<Sub1<UInt<U, B>>> {
+impl<U, B, V, A> Index<UInt<U, B>> for TArr<V, A>
+where
+    UInt<U, B>: Sub<B1>,
+    A: Index<Sub1<UInt<U, B>>>,
+{
     type Output = Idx<A, Sub1<UInt<U, B>>>;
 }
 
@@ -36,7 +40,11 @@ impl<A, New, Old> SetIndex<U0, New> for TArr<Old, A> {
     type Output = TArr<New, A>;
 }
 
-impl<U, B, V, A, New> SetIndex<UInt<U, B>, New> for TArr<V, A> where UInt<U, B>: Sub<B1>, A: SetIndex<Sub1<UInt<U, B>>, New> {
+impl<U, B, V, A, New> SetIndex<UInt<U, B>, New> for TArr<V, A>
+where
+    UInt<U, B>: Sub<B1>,
+    A: SetIndex<Sub1<UInt<U, B>>, New>,
+{
     type Output = TArr<V, Set<A, Sub1<UInt<U, B>>, New>>;
 }
 
@@ -48,7 +56,6 @@ pub struct Decrement<R, I1, I2> {
     _marker: PhantomData<(R, I1, I2)>,
 }
 pub struct Halt;
-
 
 // Evaluate
 pub trait Eval<Instruction> {
@@ -62,18 +69,25 @@ impl<Registers, Instructions> Eval<Halt> for (Registers, Instructions) {
 }
 
 // Increment
-impl<Registers, Instructions, Reg, Ins> Eval<Increment<Reg, Ins>> for (Registers, Instructions) where
+impl<Registers, Instructions, Reg, Ins> Eval<Increment<Reg, Ins>> for (Registers, Instructions)
+where
     Registers: Index<Reg>,
     Idx<Registers, Reg>: Add<B1>,
     Registers: SetIndex<Reg, Add1<Idx<Registers, Reg>>>,
     Instructions: Index<Ins>,
     (Set<Registers, Reg, Add1<Idx<Registers, Reg>>>, Instructions): Eval<Idx<Instructions, Ins>>,
 {
-    type Output = Evaluate<Set<Registers, Reg, Add1<Idx<Registers, Reg>>>, Instructions, Idx<Instructions, Ins>>;
+    type Output = Evaluate<
+        Set<Registers, Reg, Add1<Idx<Registers, Reg>>>,
+        Instructions,
+        Idx<Instructions, Ins>,
+    >;
 }
 
 // Decrement, first step
-impl<Registers, Instructions, Reg, I1, I2> Eval<Decrement<Reg, I1, I2>> for (Registers, Instructions) where
+impl<Registers, Instructions, Reg, I1, I2> Eval<Decrement<Reg, I1, I2>>
+    for (Registers, Instructions)
+where
     Registers: Index<Reg>,
     (Registers, Instructions): PrivateDecrement<Reg, I1, I2, Idx<Registers, Reg>>,
 {
@@ -87,7 +101,9 @@ pub type PrivateDecrementOut<Registers, Instructions, Reg, I1, I2, Value> =
     <(Registers, Instructions) as PrivateDecrement<Reg, I1, I2, Value>>::Output;
 
 // PrivateDecrement, Register is zero
-impl<Registers, Instructions, Reg, I1, I2> PrivateDecrement<Reg, I1, I2, U0> for (Registers, Instructions) where
+impl<Registers, Instructions, Reg, I1, I2> PrivateDecrement<Reg, I1, I2, U0>
+    for (Registers, Instructions)
+where
     Instructions: Index<I1>,
     (Registers, Instructions): Eval<Idx<Instructions, I1>>,
 {
@@ -96,14 +112,20 @@ impl<Registers, Instructions, Reg, I1, I2> PrivateDecrement<Reg, I1, I2, U0> for
 
 // PrivateDecrement, Register is non-zero
 impl<Registers, Instructions, Reg, I1, I2, U, B> PrivateDecrement<Reg, I1, I2, UInt<U, B>>
-    for (Registers, Instructions) where
+    for (Registers, Instructions)
+where
     Registers: Index<Reg>,
     Idx<Registers, Reg>: Sub<B1>,
     Registers: SetIndex<Reg, Sub1<Idx<Registers, Reg>>>,
     Instructions: Index<I2>,
     (Set<Registers, Reg, Sub1<Idx<Registers, Reg>>>, Instructions): Eval<Idx<Instructions, I2>>,
 {
-    type Output = Evaluate<Set<Registers, Reg, Sub1<Idx<Registers, Reg>>>, Instructions, Idx<Instructions, I2>>;
+    type Output = Evaluate<
+        Set<Registers, Reg, Sub1<Idx<Registers, Reg>>>,
+        Instructions,
+        Idx<Instructions, I2>,
+    >;
 }
 
-pub type Execute<Registers, Instructions> = Evaluate<Registers, Instructions, Idx<Instructions, U0>>;
+pub type Execute<Registers, Instructions> =
+    Evaluate<Registers, Instructions, Idx<Instructions, U0>>;


### PR DESCRIPTION
New versions of GenericArray don't have a `new` function, so we switch
to `default`, and specify versions of our dependencies.

Also ran rustfmt for good measure.

Fixes #1.